### PR TITLE
keep track of latest patch release

### DIFF
--- a/versions/2023/2023.4.json
+++ b/versions/2023/2023.4.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://version.goauthentik.io/schema.json",
+    "stable": {
+        "version": "2023.4.1",
+        "changelog": "See https://goauthentik.io/docs/releases/2023.4#fixed-in-202341",
+        "reason": "bugfix"
+    }
+}


### PR DESCRIPTION
Keep track of latest patch release for every release, so the update checker can check for patch updates for it's version and also the overall last version